### PR TITLE
add oebb to module list 🎉

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -11,5 +11,6 @@ Module | Operator | 🏳️ | First added | [`stations.all`](docs/stations-stops
 [`korail`](https://github.com/juliuste/korail) | [Korail](https://www.letskorail.com/) | 🇰🇷 | *2019-06-23* in `2.0.0` |  ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 [`train-ose`](https://github.com/juliuste/train-ose) | [TrainOSE](https://www.trainose.gr/) | 🇬🇷 | *2019-06-23* in `1.0.0` |  ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 [`slovenske-zeleznice`](https://github.com/juliuste/slovenske-zeleznice) | [Slovenske železnice (SŽ)](http://www.slo-zeleznice.si/) | 🇸🇮 | *2019-06-23* in `1.0.0` |  ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
+[`oebb`](https://github.com/juliuste/oebb) | [Österreichische Bundesbahnen (ÖBB)](https://www.oebb.at/) | 🇦🇹 | *2019-10-27* in `1.0.0` |  ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌
 
 \*Not an operator, probably still interesting though


### PR DESCRIPTION
The [`oebb` module](https://github.com/juliuste/oebb) is now FPTI compatible 🎉.